### PR TITLE
Feature/register user post request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ add_executable(MyQtApp
         key_management/DataEncryptionKey.cpp
         key_management/KeyEncryptor.h
         key_management/KeyEncryptor.cpp
+        FrontEnd/RegisterPage/registerManager.cpp
+        FrontEnd/RegisterPage/registerManager.h
 )
 
 target_include_directories(MyQtApp PRIVATE

--- a/FrontEnd/RegisterPage/registerManager.cpp
+++ b/FrontEnd/RegisterPage/registerManager.cpp
@@ -1,0 +1,136 @@
+#include "registerManager.h"
+#include <QDebug>
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QSslSocket>
+#include <QSslConfiguration>
+#include <QNetworkReply>
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include "../../key_management/X3DHKeys/IdentityKeyPair.h"
+#include "../../key_management/X3DHKeys/SignedPreKeyPair.h"
+#include "../../key_management/X3DHKeys/OneTimeKeyPair.h"
+
+RegisterManager::RegisterManager(QObject *parent) : QObject(parent),
+                                                    networkManager(new QNetworkAccessManager(this)),
+                                                    currentReply(nullptr)
+{
+    if (!QSslSocket::supportsSsl()) {
+        qWarning() << "SSL is not supported on this system";
+    }
+}
+
+RegisterManager::~RegisterManager()
+{
+    if (currentReply) {
+        currentReply->abort();
+        currentReply->deleteLater();
+    }
+}
+
+void RegisterManager::setServerUrl(const QString &url) {
+    serverUrl = url;
+}
+
+bool RegisterManager::registerUser(const QString &username, int numOneTimeKeys) {
+    qDebug() << "Registering user with server:" << username;
+    qDebug() << "Generating" << numOneTimeKeys << "one-time keys";
+
+    if (username.isEmpty()) {
+        emit registrationFailed("Username cannot be empty.");
+        return false;
+    }
+
+    if (serverUrl.isEmpty()) {
+        emit registrationFailed("Server URL is not set.");
+        return false;
+    }
+
+    try {
+        // Generate X3DH keys for the user
+        IdentityKeyPair identityKeys;
+        SignedPreKeyPair signedPreKeys(identityKeys.getPrivateKey());
+
+        QJsonArray oneTimeKeysArray;
+        for (int i = 0; i< numOneTimeKeys; i++) {
+            OneTimeKeyPair oneTimeKey;
+            const auto& keyData = oneTimeKey.getPublicKey();
+            QByteArray keyBytes(reinterpret_cast<const char*>(keyData.data()), keyData.size());
+            QString base64Key = QString::fromLatin1(keyBytes.toBase64());
+
+            oneTimeKeysArray.append(base64Key);
+        }
+
+        // Create JSON payload
+        QJsonObject registrationData;
+        registrationData["username"] = username;
+        registrationData["identityPublicKey"] = QString::fromLatin1(QByteArray(reinterpret_cast<const char*>(identityKeys.getPublicKey().data()), identityKeys.getPublicKey().size()).toBase64());
+        registrationData["signedPreKeyPublicKey"] = QString::fromLatin1(QByteArray(reinterpret_cast<const char*>(signedPreKeys.getPublicKey().data()), signedPreKeys.getPublicKey().size()).toBase64());
+        registrationData["signedPreKeySignature"] = QString::fromLatin1(QByteArray(reinterpret_cast<const char*>(signedPreKeys.getSignature().data()), signedPreKeys.getSignature().size()).toBase64());
+        registrationData["oneTimeKeys"] = oneTimeKeysArray;
+
+        QJsonDocument jsonDoc(registrationData);
+        QByteArray jsonData = jsonDoc.toJson();
+
+        // Create network request
+        QNetworkRequest request(QUrl(serverUrl + "/auth/register"));
+        request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+
+        // SSL configuration
+        QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
+        sslConfig.setPeerVerifyMode(QSslSocket::VerifyNone);
+        request.setSslConfiguration(sslConfig);
+
+        // Send POST request
+        currentReply = networkManager->post(request, jsonData);
+
+        // Connect signals
+        connect(currentReply, &QNetworkReply::finished,
+                this, &RegisterManager::handleRegistrationFinished);
+        connect(currentReply, &QNetworkReply::sslErrors,
+                this, &RegisterManager::handleSslErrors);
+        connect(currentReply, &QNetworkReply::errorOccurred,
+                this, &RegisterManager::handleNetworkError);
+
+        return true;
+
+    } catch (const std::exception& e) {
+        emit registrationFailed(QString("Failed to generate X3DH keys: %1").arg(e.what()));
+        return false;
+    }
+}
+
+void RegisterManager::handleRegistrationFinished()
+{
+    if (currentReply->error() == QNetworkReply::NoError) {
+        QByteArray response = currentReply->readAll();
+        qDebug() << "Registration successful. Server response:" << response;
+        emit registrationSucceeded();
+    } else {
+        QString errorMsg = QString("Registration failed: %1").arg(currentReply->errorString());
+        qDebug() << errorMsg;
+        emit registrationFailed(errorMsg);
+    }
+
+    currentReply->deleteLater();
+    currentReply = nullptr;
+}
+
+void RegisterManager::handleSslErrors(const QList<QSslError> &errors) {
+    qDebug() << "SSL errors detected, but ignoring for testing:";
+    for (const QSslError &error : errors) {
+        qDebug() << "  -" << error.errorString();
+    }
+
+    if (currentReply) {
+        currentReply->ignoreSslErrors();
+    }
+}
+
+void RegisterManager::handleNetworkError(QNetworkReply::NetworkError error)
+{
+    QString errorString = currentReply->errorString();
+    qDebug() << "Network error occurred during registration:" << errorString;
+    emit registrationFailed(errorString);
+}

--- a/FrontEnd/RegisterPage/registerManager.h
+++ b/FrontEnd/RegisterPage/registerManager.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QSslError>
+
+class RegisterManager : public QObject
+{
+Q_OBJECT
+
+public:
+    explicit RegisterManager(QObject *parent = nullptr);
+    static constexpr int DEFAULT_ONETIME_KEYS = 10;
+    ~RegisterManager();
+
+    void setServerUrl(const QString &url);
+    bool registerUser(const QString &username, int numOneTimeKeys = DEFAULT_ONETIME_KEYS);
+
+signals:
+    void registrationSucceeded();
+    void registrationFailed(const QString &error);
+
+private slots:
+    void handleRegistrationFinished();
+    void handleSslErrors(const QList<QSslError> &errors);
+    void handleNetworkError(QNetworkReply::NetworkError error);
+
+private:
+    QNetworkAccessManager *networkManager;
+    QNetworkReply *currentReply;
+    QString serverUrl;
+};

--- a/FrontEnd/RegisterPage/registerpage.h
+++ b/FrontEnd/RegisterPage/registerpage.h
@@ -1,10 +1,11 @@
-#ifndef REGISTERPAGE_H
-#define REGISTERPAGE_H
+#pragma once
 
 #include <QDialog>
 #include "../../auth/UserAuthentication.h"
 #include "../../auth/validation.h"
 #include "../../auth/CommonPasswordChecker.h"
+#include "registerManager.h"
+
 
 namespace Ui {
 class RegisterPage;
@@ -22,6 +23,8 @@ public:
 private slots:
     void on_registerButton_clicked();
     void on_backToLoginButton_clicked();
+    void onServerRegistrationSucceeded();
+    void onServerRegistrationFailed(const QString &error);
 
 private:
     Ui::RegisterPage *ui; // Pointer to the auto-generated UI class
@@ -30,8 +33,9 @@ private:
     CommonPasswordChecker* passwordChecker;
     PasswordValidator* passwordValidator;
     UserAuthentication* userAuth;
+    RegisterManager* registerManager;
+
 
     int failed;
 };
 
-#endif 


### PR DESCRIPTION
Added registerManager.cpp and registerManager.h to handle the POST request to gobbler when registering a user. This makes a JSON body with "username", "identityPublicKey", "signedPrePublicKey", "signedPreKeySignature", and "oneTimeKeys". All of these (besides username) are sent in base64 encoded bytes.
Modified registerpage.cpp to contact gobbler and use registerManager.cpp to send the POST request. If successful, user gets registered and redirected to login page.

Also added Paddy's X3DH functionality